### PR TITLE
Remove flex order specific exercises from flex froggy

### DIFF
--- a/chapters/chapter3.html
+++ b/chapters/chapter3.html
@@ -457,7 +457,7 @@
         </section>
         <section class="exercise">
             <span class="title">Exercise 1</span>
-            <span class="description">Try to solve levels 1-17 of <a href="https://flexboxfroggy.com/">Flexbox froggy</a></span>
+            <span class="description">Try to solve levels 1-13 and 16 of <a href="https://flexboxfroggy.com/">Flexbox froggy</a></span>
         </section>
         <section>
             <section class="subtitle-slide">
@@ -603,7 +603,7 @@
         </section>
         <section class="exercise">
             <span class="title">Exercise 2</span>
-            <span class="description">Try to solve levels 17-24 of <a href="https://flexboxfroggy.com/">Flexbox froggy</a></span>
+            <span class="description">Try to solve levels 18-23 of <a href="https://flexboxfroggy.com/">Flexbox froggy</a></span>
         </section>
         <section>
             <h2>Build person card</h2>


### PR DESCRIPTION
Remove the order specific exercises. Removing the ones that include flex-direction: row-reverse is a bit more difficult unfortunately as that is integrated into other exercises that are useful IMO.